### PR TITLE
Scroll restoration on page navigation and refresh

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,9 @@ const nextConfig = {
     locales: ['no'],
     defaultLocale: 'no',
   },
+  experimental: {
+    scrollRestoration: true,
+  },
   async rewrites() {
     return [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-intersection-observer": "^9.4.1",
         "sass": "^1.55.0",
         "sharp": "^0.31.2",
-        "swr": "^2.0.0-rc.3",
+        "swr": "^2.0.3",
         "typescript": "4.8.4",
         "zustand": "^4.3.3"
       }
@@ -3984,9 +3984,9 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.0-rc.3.tgz",
-      "integrity": "sha512-HYbm4LGmvM1M3avtmGeJD7YZskbzRcD9xTFsIXmHDJ85b05NCy+3U1EO9RBNE0d6GHx65WEl8K313+vo1fKaKw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.3.tgz",
+      "integrity": "sha512-sGvQDok/AHEWTPfhUWXEHBVEXmgGnuahyhmRQbjl9XBYxT/MSlAzvXEKQpyM++bMPaI52vcWS2HiKNaW7+9OFw==",
       "dependencies": {
         "use-sync-external-store": "^1.2.0"
       },
@@ -6972,9 +6972,9 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "swr": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.0-rc.3.tgz",
-      "integrity": "sha512-HYbm4LGmvM1M3avtmGeJD7YZskbzRcD9xTFsIXmHDJ85b05NCy+3U1EO9RBNE0d6GHx65WEl8K313+vo1fKaKw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.3.tgz",
+      "integrity": "sha512-sGvQDok/AHEWTPfhUWXEHBVEXmgGnuahyhmRQbjl9XBYxT/MSlAzvXEKQpyM++bMPaI52vcWS2HiKNaW7+9OFw==",
       "requires": {
         "use-sync-external-store": "^1.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-intersection-observer": "^9.4.1",
     "sass": "^1.55.0",
     "sharp": "^0.31.2",
-    "swr": "^2.0.0-rc.3",
+    "swr": "^2.0.3",
     "typescript": "4.8.4",
     "zustand": "^4.3.3"
   }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -6,10 +6,6 @@ import { Up } from '@navikt/ds-icons'
 const Footer = () => (
   <footer className="nav-bunn">
     <div className="nav-bunn__content">
-      <Link href="#">
-        <Up title="Til toppen" />
-        Til toppen
-      </Link>
       <div className="nav-bunn__info">
         <Image src="/nav-logo-black.svg" alt="Test" width={60} height={37} />
         <div>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,8 +1,6 @@
-import { forwardRef, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form'
-import { useInView } from 'react-intersection-observer'
-import classNames from 'classnames'
 import { Button, Search, Switch } from '@navikt/ds-react'
 import { Collapse, Delete, Expand } from '@navikt/ds-icons'
 import { FilterData, SearchData } from '../../utils/api-util'
@@ -12,13 +10,11 @@ import { initialSearchDataState, useHydratedSearchStore } from '../../utils/sear
 import FilterView from './FilterView'
 import SelectIsoCategory from './SelectIsoCategory'
 
-const Sidebar = ({ filters }: { filters?: FilterData }) => {
+const Sidebar = ({ filters, onResetSearchData }: { filters?: FilterData; onResetSearchData: () => void }) => {
   const router = useRouter()
-  const { searchData, setSearchData, resetSearchData, meta: searchDataMeta } = useHydratedSearchStore()
+  const { searchData, setSearchData } = useHydratedSearchStore()
   const [productSearchParams] = useState(mapProductSearchParams(router.query))
   const [expanded, setExpanded] = useState(false)
-
-  const { ref: resetButtonRef, inView: isResetButtonVisible } = useInView({ threshold: 0.4 })
 
   const formMethods = useForm<SearchData>({
     defaultValues: {
@@ -27,20 +23,13 @@ const Sidebar = ({ filters }: { filters?: FilterData }) => {
     },
   })
 
-  const {
-    control,
-    formState: { isDirty },
-    handleSubmit,
-    reset: resetForm,
-    setValue,
-  } = formMethods
+  const { control, handleSubmit, reset: resetForm, setValue } = formMethods
 
   const onSubmit: SubmitHandler<SearchData> = (data) => setSearchData({ ...data })
 
   const onReset = () => {
-    resetSearchData()
+    onResetSearchData()
     resetForm(initialSearchDataState)
-    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   const Chevron = expanded ? Collapse : Expand
@@ -90,11 +79,14 @@ const Sidebar = ({ filters }: { filters?: FilterData }) => {
             </>
           )}
 
-          <ResetButton onClick={onReset} ref={resetButtonRef} />
-
-          {(isDirty || searchDataMeta.isUnlikeInitial) && !isResetButtonVisible && (
-            <ResetButton fixed onClick={onReset} />
-          )}
+          <Button
+            type="button"
+            className="search__reset-button"
+            icon={<Delete title="Nullstill søket" />}
+            onClick={onReset}
+          >
+            Nullstill søket
+          </Button>
         </form>
       </FormProvider>
       <Button
@@ -109,25 +101,5 @@ const Sidebar = ({ filters }: { filters?: FilterData }) => {
     </div>
   )
 }
-
-const ResetButton = forwardRef<HTMLButtonElement, { onClick: () => void; fixed?: boolean }>(function RButton(
-  { onClick, fixed = false },
-  ref
-) {
-  return (
-    <Button
-      type="button"
-      className={classNames({
-        'search__reset-button': !fixed,
-        'search__reset-button--fixed': fixed,
-      })}
-      icon={<Delete title="Nullstill søket" />}
-      onClick={onClick}
-      ref={ref}
-    >
-      Nullstill søket
-    </Button>
-  )
-})
 
 export default Sidebar

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+
+export default function useDebounce<T>(value: T, delay?: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay || 500)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/src/hooks/useRestoreScroll.ts
+++ b/src/hooks/useRestoreScroll.ts
@@ -1,0 +1,58 @@
+import { useEffect, useLayoutEffect, useState } from 'react'
+import useDebounce from './useDebounce'
+
+export default function useRestoreScroll(id: string, shouldRestore: boolean) {
+  const [scrollTop, setScrollTop] = useState<Number>()
+  const debouncedScrollTop = useDebounce(scrollTop, 100)
+  const SESSION_STORAGE_ID = `restore-scroll-${id}`
+
+  /**
+   * Restore previous scroll position
+   */
+  useLayoutEffect(() => {
+    try {
+      if (shouldRestore) {
+        const storedValue = sessionStorage.getItem(SESSION_STORAGE_ID)
+        if (storedValue) {
+          window.scrollTo(0, parseInt(storedValue, 10))
+        }
+      }
+    } catch (error) {
+      // ignore sessionStorage error
+    }
+  }, [SESSION_STORAGE_ID, shouldRestore])
+
+  /**
+   * Listen to scroll event, and track current scroll position
+   */
+  useEffect(() => {
+    try {
+      if (shouldRestore) {
+        function handleScroll() {
+          setScrollTop(Math.round(window.pageYOffset || document.documentElement.scrollTop))
+        }
+
+        window.addEventListener('scroll', handleScroll)
+
+        return () => {
+          window.removeEventListener('scroll', handleScroll)
+        }
+      }
+    } catch (error) {
+      // ignore sessionStorage error
+    }
+  }, [shouldRestore])
+
+  /**
+   * Store current scroll position
+   */
+  useEffect(() => {
+    try {
+      if (debouncedScrollTop !== undefined) {
+        sessionStorage.setItem(SESSION_STORAGE_ID, `${debouncedScrollTop}`)
+      }
+    } catch (error) {
+      // ignore sessionStorage error
+    }
+  }, [SESSION_STORAGE_ID, debouncedScrollTop])
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,11 +2,10 @@ import { useEffect, useState } from 'react'
 import { InferGetServerSidePropsType, NextPageContext } from 'next'
 import Router from 'next/router'
 import useSWRInfinite from 'swr/infinite'
-import * as queryString from 'querystring'
 import { Loader } from '@navikt/ds-react'
-import { useHydratedSearchStore } from '../utils/search-state-util'
+import { initialSearchDataState, useHydratedSearchStore } from '../utils/search-state-util'
 import { CompareMode, useHydratedCompareStore } from '../utils/compare-state-util'
-import { fetchProducts, FetchResponse, SelectedFilters } from '../utils/api-util'
+import { fetchProducts, FetchResponse, PAGE_SIZE, SearchParams } from '../utils/api-util'
 import { mapProductSearchParams, toSearchQueryString } from '../utils/product-util'
 
 import AnimateLayout from '../components/layout/AnimateLayout'
@@ -16,36 +15,56 @@ import Sidebar from '../components/sidebar/Sidebar'
 
 export const getServerSideProps: (
   context: NextPageContext
-) => Promise<{ props: { query: queryString.ParsedUrlQuery } }> = async (context: NextPageContext) => {
+) => Promise<{ props: { searchParams: SearchParams } }> = async (context: NextPageContext) => {
   const { query } = context
-  return { props: { query } }
+  return { props: { searchParams: mapProductSearchParams(query) } }
 }
 
-export default function Home({ query }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function Home({ searchParams }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { searchData, setSearchData } = useHydratedSearchStore()
   const { compareMode } = useHydratedCompareStore()
 
-  const [productSearchParams] = useState(mapProductSearchParams(query))
+  const [initialProductSearchParams, setInitialProductSearchParams] = useState(searchParams)
   const [searchInitialized, setSearchInitialized] = useState(false)
 
   const { data, size, setSize, isLoading } = useSWRInfinite<FetchResponse>(
-    (index) => ({ url: `/products/_search`, pageIndex: index, searchData }),
+    (index) => {
+      const from = index !== 0 ? (initialProductSearchParams.to || PAGE_SIZE) + (index - 1) * PAGE_SIZE : 0
+      const to = (index === 0 && initialProductSearchParams.to) || PAGE_SIZE
+      return {
+        url: `/products/_search`,
+        from,
+        to,
+        searchData,
+      }
+    },
     fetchProducts,
     {
       keepPreviousData: true,
     }
   )
 
-  useEffect(() => {
-    setSearchData(productSearchParams)
-    setSearchInitialized(true)
-  }, [productSearchParams, setSearchData])
+  useEffect(() => setSearchData(initialProductSearchParams), [initialProductSearchParams, setSearchData])
+
+  useEffect(() => setSearchInitialized(true), [data])
+
+  const products = data?.flatMap((d) => d.products)
+  const numberOfProducts = products && products.length > PAGE_SIZE ? products.length : undefined
 
   useEffect(() => {
     if (searchInitialized) {
-      Router.push(toSearchQueryString(searchData))
+      Router.push(
+        toSearchQueryString({
+          ...searchData,
+          to: numberOfProducts,
+        }),
+        undefined,
+        {
+          scroll: false,
+        }
+      )
     }
-  }, [searchInitialized, searchData])
+  }, [searchInitialized, searchData, numberOfProducts])
 
   return (
     <>
@@ -53,7 +72,13 @@ export default function Home({ query }: InferGetServerSidePropsType<typeof getSe
       <AnimateLayout>
         <div className="main-wrapper">
           <div className="flex-column-wrap">
-            <Sidebar filters={data?.at(-1)?.filters} />
+            <Sidebar
+              filters={data?.at(-1)?.filters}
+              onResetSearchData={() => {
+                setInitialProductSearchParams({ ...initialSearchDataState, to: undefined })
+                setSize(1)
+              }}
+            />
             <div className="results__wrapper">
               {!data && <Loader className="results__loader" size="3xlarge" title="Laster produkter" />}
               {data && <SearchResults data={data} size={size} setSize={setSize} isLoading={isLoading} />}

--- a/src/styles/search.scss
+++ b/src/styles/search.scss
@@ -36,13 +36,13 @@
   &__reset-button {
     width: 100%;
     margin-bottom: var(--a-spacing-4);
+  }
 
-    &--fixed {
-      position: fixed;
-      right: var(--a-spacing-4);
-      bottom: var(--a-spacing-4);
-      z-index: 999;
-    }
+  &__page-up-button {
+    position: fixed;
+    top: var(--a-spacing-4);
+    right: var(--a-spacing-4);
+    z-index: 999;
   }
 
   &__expand-button {

--- a/src/utils/api-util.ts
+++ b/src/utils/api-util.ts
@@ -1,5 +1,5 @@
 import { FilterCategories } from './filter-util'
-import { createProduct, mapProducts, Product } from './product-util'
+import { mapProducts, Product } from './product-util'
 import {
   filterBredde,
   filterLengde,
@@ -14,9 +14,8 @@ import {
   filterTotalvekt,
   toMinMaxAggs,
 } from './filter-util'
-import { mapSupplier, Supplier } from './supplier-util'
 
-export const PAGE_SIZE = 15
+export const PAGE_SIZE = 25
 
 export type SelectedFilters = Record<keyof typeof FilterCategories, Array<any>>
 export type Bucket = { key: number | string; doc_count: number }
@@ -48,9 +47,12 @@ export type SearchData = {
   filters: SelectedFilters
 }
 
+export type SearchParams = SearchData & { to?: number }
+
 type FetchProps = {
   url: string
-  pageIndex: number
+  from: number
+  to: number
   searchData: SearchData
 }
 
@@ -60,8 +62,7 @@ export type FetchResponse = {
   filters: FilterData
 }
 
-export const fetchProducts = ({ url, pageIndex, searchData }: FetchProps): Promise<FetchResponse> => {
-  const from = pageIndex * PAGE_SIZE
+export const fetchProducts = ({ url, from, to, searchData }: FetchProps): Promise<FetchResponse> => {
   const { searchTerm, isoCode, hasRammeavtale, filters } = searchData
   const {
     lengdeCM,
@@ -144,7 +145,7 @@ export const fetchProducts = ({ url, pageIndex, searchData }: FetchProps): Promi
     },
     body: JSON.stringify({
       from,
-      size: PAGE_SIZE,
+      size: to,
       query,
       post_filter,
       aggs: {

--- a/src/utils/product-util.ts
+++ b/src/utils/product-util.ts
@@ -1,3 +1,4 @@
+import queryString from 'querystring'
 import { FilterCategories } from './filter-util'
 import {
   Hit,
@@ -8,8 +9,7 @@ import {
   TechDataResponse,
 } from './response-types'
 import { initialSearchDataState } from './search-state-util'
-import queryString from 'querystring'
-import { SearchData, SelectedFilters } from './api-util'
+import { SearchParams, SelectedFilters } from './api-util'
 
 export interface Product {
   id: string
@@ -92,6 +92,7 @@ export const mapProductSearchParams = (searchParams: { [key: string]: any }) => 
   const searchTerm = searchParams.term ?? ''
   const isoCode = searchParams.isoCode ?? ''
   const hasRammeavtale = searchParams.agreement ? searchParams.agreement === 'true' : true
+  const to = parseInt(searchParams.to) ?? undefined
 
   const filterKeys = Object.keys(FilterCategories).filter((filter) =>
     Array.from(Object.keys(searchParams)).includes(filter)
@@ -104,16 +105,18 @@ export const mapProductSearchParams = (searchParams: { [key: string]: any }) => 
     isoCode,
     hasRammeavtale,
     filters: { ...initialSearchDataState.filters, ...filters },
+    to,
   }
 }
 
-export const toSearchQueryString = (searchData: SearchData) =>
+export const toSearchQueryString = (searchParams: SearchParams) =>
   '?' +
   queryString.stringify({
-    agreement: searchData.hasRammeavtale,
-    ...(searchData.searchTerm && { term: searchData.searchTerm }),
-    ...(searchData.isoCode && { isoCode: searchData.isoCode }),
-    ...Object.entries(searchData.filters)
+    agreement: searchParams.hasRammeavtale,
+    ...(searchParams.searchTerm && { term: searchParams.searchTerm }),
+    ...(searchParams.isoCode && { isoCode: searchParams.isoCode }),
+    ...Object.entries(searchParams.filters)
       .filter(([_, values]) => values.some((value) => !(isNaN(value) || value === null || value === undefined)))
       .reduce((newObject, [key, values]) => ({ ...newObject, [key]: values }), {} as SelectedFilters),
+    ...(searchParams.to && { to: searchParams.to }),
   })


### PR DESCRIPTION
- Add "to" as URL param (used for fetching the correct number of products and thus enabling scroll restoration)
- Add useRestoreScroll hook for restoring scroll position between page navigation
- Activate experimental scrollRestoration in Next.js (this prevents the page from jumping to the bottom before navigating)
- Increase PAGE_SIZE from 15 to 25
- Bump swr to v2.0.3
- Remove "Til toppen" button in footer (is replaced by a floating button which is always visible)
- Remove floating "Nullstill søket" button