### PR TITLE
Fikser line height i henhold til resultater fra SiteImprove

### DIFF
--- a/src/components/information-tabs/InformationTabs.tsx
+++ b/src/components/information-tabs/InformationTabs.tsx
@@ -48,9 +48,9 @@ const SupplierInfo = ({ product, supplier }: { product: Product; supplier: Suppl
       Leverandør
     </Heading>
     <>
-      <BodyLong>{supplier.name}</BodyLong>
-      {supplier.address && <BodyLong>{supplier.address}</BodyLong>}
-      {supplier.email && <BodyLong>{supplier.email}</BodyLong>}
+      <BodyShort>{supplier.name}</BodyShort>
+      {supplier.address && <BodyShort>{supplier.address}</BodyShort>}
+      {supplier.email && <BodyShort>{supplier.email}</BodyShort>}
       {supplier.homepageUrl && (
         <Link href={supplier?.homepageUrl} target="_blank" rel="noreferrer">
           Hjemmeside (åpnes i ny side)


### PR DESCRIPTION
12.06.2023: Etter en del detektivarbeid fant jeg ut at SiteImprove ikke alltid har rett når det gjelder line-height. SiteImprove er litt for enkel og tar ikke hensyn til spacing (margin, padding, spacing, gap) og dermed kan det se ut som vi har mange feil som ikke stemmer. Jeg har revertet de endringene som jeg egentlig ikke trengte å gjøre. Har også undersøkt alle feilene på søkesiden ved å bruke plug-in og alt er egentlig i orden når det gjelder line-height. Eneste stedet SiteImprove egentlig har rett er i prototypeteksten 


TIDLIGERE:
### Beskrivelse
En av feilene som kom opp i rapporten fra SiteImprove var at linjehøyden noen steder er under minimumsverdien på 1.5 ganger font-size. Dette forkom 1 905 ganger på hele nettsiden. Feilene oppstår i de samme komponentene på alle sider så det er ikke så mange feil som det ser ut som. 

### Løsning
Etter litt gransking 🤪 fant jeg ut at der det brukes en BodyShort og teksten går over flere linjer eller det har blitt brukt flere BodyShort under hverandre er ikke line height 1.5 ganger font-size (som er WCAG-kravet på nivå AAA). Slik jeg tolker Aksel skal det brukes BodyLong når teksten går over flere linjer og BodyShort når det kun er én linje. Når det kun er én linje så har ikke line height noe å si fordi det ikke finnes noe over eller under. Line height er 1.5 ganger større en font-size når man bruker BodyLong og derfor har jeg byttet ut med BodyLong der SiteImprove oppgir at problemet oppstår.

Mulig jeg har misforstått Aksel totalt, så det er bare å si ifra så finner vi en annen løsning 😅 

### Bilder

|Bilde før (SiteImprove) |Bilde etter (justert line height)|
|--------|-----------|
|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/80ce8446-8a4a-47d1-bcdc-aa49ae341fbe)|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/8288d33b-a4bf-4632-a125-a89682e83004)|
|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/364ee587-154e-4813-a00c-efad76ef75b2)|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/b620cd0b-bd41-4d47-9bf5-d932ab9f075e)|
|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/a1f4c303-0041-4915-8089-c676ca75b7b6)|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/827cb995-8972-4ad3-a4ed-cefe9ca10706)|
|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/0bc09823-1e50-4327-ad36-8f3e5818ee36)|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/eacf251a-7fa8-413f-a5eb-c2b36547f1d2)|

Èn feil har jeg ikke rettet opp i fordi jeg ikke kan forstå at det er et problem. Her er det nok spacing over og under teksten..🤷‍♀️ Det virker som at SiteImprove ikke tar med spacing i betrakning og kun ser font-size og line height på akkurat det elementet. 

![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/bf2bb750-f2c1-4b3e-9dcd-9f5fdf1b4e64)



