### PR TITLE
♿️ Legger til aria-labels

### DIFF
--- a/src/components/photo-slider/PhotoSlider.tsx
+++ b/src/components/photo-slider/PhotoSlider.tsx
@@ -95,6 +95,7 @@ const PhotoSlider = ({ photos }: ImageSliderProps) => {
         {numberOfImages > 1 && (
           <>
             <Button
+              aria-label="Forrige bilde"
               variant="tertiary-neutral"
               className="arrow"
               onClick={() => {
@@ -149,6 +150,7 @@ const PhotoSlider = ({ photos }: ImageSliderProps) => {
               </AnimatePresence>
             </div>
             <Button
+              aria-label="Neste bilde"
               variant="tertiary-neutral"
               className="arrow"
               onClick={() => {
@@ -164,6 +166,8 @@ const PhotoSlider = ({ photos }: ImageSliderProps) => {
           if (index !== active) {
             return (
               <Button
+                aria-selected="false"
+                aria-label="bilde"
                 key={index}
                 className={'dot'}
                 onClick={() => {
@@ -172,7 +176,7 @@ const PhotoSlider = ({ photos }: ImageSliderProps) => {
               />
             )
           } else {
-            return <div key={index} className="activeDot" />
+            return <div aria-selected="true" aria-label="bilde" key={index} className="activeDot" />
           }
         })}
       </div>


### PR DESCRIPTION
### Beskrivelse

Siteimprove-rapport viste at det manglet beskrivende labels/alt-tekst på pilene på hver side av bildet og prikkene under bildet på produktsiden. Dette må de ha siden vektorbildene er ikke dekorative.

![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/86f93d9e-ad53-45ba-895f-4efc5a1b37d1)

### Løsning

Legger til aria-labels og aria-selected (på prikkene) i samråd med David 😁