### PR TITLE
Bugfix: Synkronisering av søkeparametre, søkeord og søkedata

### DIFF
--- a/src/app/sok/page.tsx
+++ b/src/app/sok/page.tsx
@@ -118,6 +118,10 @@ export default function Home() {
     }
   }, [data])
 
+  useEffect(() => {
+    setProductSearchParams(mapProductSearchParams(searchParams))
+  }, [searchParams, setProductSearchParams])
+
   useEffect(() => setSearchData(productSearchParams), [productSearchParams, setSearchData])
 
   const onReset = () => {

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle } from 'react'
+import React, { forwardRef, useEffect, useImperativeHandle } from 'react'
 import { Controller, SubmitHandler, useFormContext } from 'react-hook-form'
 
 import { Button, Search, Switch } from '@navikt/ds-react'
@@ -28,6 +28,10 @@ const SearchForm = forwardRef<SearchFormResetHandle, Props>(({ filters, setFocus
   const { control, handleSubmit, reset: resetForm, setValue } = useFormContext<SearchData>()
 
   const onSubmit: SubmitHandler<SearchData> = (data) => setSearchData({ ...data })
+
+  useEffect(() => {
+    setValue('searchTerm', searchData.searchTerm)
+  }, [searchData.searchTerm, setValue])
 
   useImperativeHandle(ref, () => ({
     reset() {


### PR DESCRIPTION
### Beskrivelse
Søkeparametere i url stemte ikke overens med søkeord eller søkedata ved navigering i nettleser (frem og tilbake)

### Løsning
- Legger til en useEffect slik at productSearchParams blir oppdatert når url oppdaterer seg -> Dette skjedde kun ved første siderender tidligere
- Legger til en useEffect og oppdaterer value i input-feltet til søkeordet slik at det synkes når searchData.searchTerm endrer seg

