### PR TITLE
🐛 Bugfix: Map rammeavtalenummer til navn dersom filteret resulterer i 0 treff

### DIFF
--- a/src/app/sok/sidebar/internals/CheckboxFilterInput.tsx
+++ b/src/app/sok/sidebar/internals/CheckboxFilterInput.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
+
 import { Button, Checkbox, CheckboxGroup, Detail } from '@navikt/ds-react'
-import { FilterCategories } from '@/utils/filter-util'
+
+import { agreementKeyLabels } from '@/utils/agreement-util'
 import { Filter, SearchData } from '@/utils/api-util'
+import { FilterCategories } from '@/utils/filter-util'
 import { useHydratedSearchStore } from '@/utils/search-state-util'
 
 import ShowMore from '@/components/ShowMore'
@@ -22,6 +25,7 @@ export const CheckboxFilterInput = ({ filter }: CheckboxFilterInputProps) => {
     watch,
   } = useFormContext<SearchData>()
   const watchFilter = watch(`filters.${filterKey}`)
+
   const touched = touchedFields.filters && !!touchedFields.filters[filterKey]
 
   useEffect(() => {
@@ -73,7 +77,8 @@ export const CheckboxFilterInput = ({ filter }: CheckboxFilterInputProps) => {
             >
               {selectedUnavailableFilters?.map((f) => (
                 <Checkbox value={f} key={f}>
-                  <CheckboxLabel value={f} hitCount={0} />
+                  {/* Midlertidig mapping av agreement label frem frem til backend er riktig */}
+                  <CheckboxLabel value={f.includes('HMDB') ? agreementKeyLabels[f] : f} hitCount={0} />
                 </Checkbox>
               ))}
               {filterData?.values.slice(0, 10).map((f) => (


### PR DESCRIPTION
### Problem

Dersom man har valgt et rammeavtalefilter f.eks. manuelle rullestoler og dermed søker på et produkt som ikke finnes i denne avtalen ble "HMDB" nummeret vist i stedet for "Manuelle rullestoler (0)".

### Løsning

Sjekker om filteret som er valgt inneholder strengen "HMDB" og mapper den da om til navnet i DOM'en. Det er en Hotfix som kan fjernes når backend leverer riktig navn på rammeavtaler. Jeg hadde lyst til å unngå å mappe dette flere steder enn vi allerede gjør men får det ikke til  fordi variabelen `selectedUnavailableFilters` alltid inneholder key (som er riktig for alle utenom rammeavtaler).

@tmsolber -> Mulig du ser en bedre løsning ?  

### Bilder

| Før | Etter |
|-----|-----|
|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/bec1bd0b-5d92-46e8-915b-007c54ac1bc6)|![image](https://github.com/navikt/hm-oversikt-frontend/assets/56063879/bff75435-f9b8-4a49-9940-24004481cf2c)|