### PR TITLE
Bugfix: Sett initial animasjon til false på sammenligningsmeny

### DIFF
--- a/src/app/sok/CompareMenu.tsx
+++ b/src/app/sok/CompareMenu.tsx
@@ -161,7 +161,7 @@ const CompareMenu = () => {
   )
 
   return (
-    <AnimatePresence>
+    <AnimatePresence initial={false}>
       {compareMenuState === CompareMenuState.Open && openView}
       {compareMenuState === CompareMenuState.Minimized && miniView}
     </AnimatePresence>


### PR DESCRIPTION
Den hadde en rar oppførsel ved at den flyttet seg opp på første last, dette fikset det i dev så tror det hjelper :) 

Testes med hard refresh i dev vs prod