### PR TITLE
Legger til negativ boosting på seksualhjelpemidler i det initielle søket

### DIFF
--- a/src/app/sok/page.tsx
+++ b/src/app/sok/page.tsx
@@ -220,7 +220,7 @@ export default function Home() {
                           }
                           return (
                             <Chips.Removable
-                              key={index}
+                              key={key + value}
                               onClick={() => {
                                 setFilter(
                                   key,


### PR DESCRIPTION
Dokumentasjon: 
https://opensearch.org/docs/latest/query-dsl/compound/boosting/

Velger å booste de tre isokategoriene som inneholder seksualhjelpemidler negativt dersom ikke søkeord eller filtre finnes. Det vil si at seksualhjelpemidler forsivinner i det initielle søket. Refaktorerer også litt fordi jeg fant ut av vi uansett får alle produkter uansett selv uten et søkeord. Nå er det mer tydelig hva vi gjør i de ulike tilfellene (når søkeord er tomt, når det ikke er tomt).
