### PR TITLE
Hot fix for products that dosent have the same tech data

### DIFF
--- a/src/utils/product-util.ts
+++ b/src/utils/product-util.ts
@@ -143,15 +143,18 @@ export const mapProductWithVariants = (sources: ProductSourceResponse[]): Produc
   let commonCharacteristics: TechData = {}
 
   for (const key of allTechKeys) {
-    let firstObj = variants[0].techData[key]
+    const firstObj = variants.find((v) => key in v.techData)!.techData[key]
+
     const allTheSame =
       variants.length > 1
-        ? variants.find(
-            (obj) =>
-              obj.techData[key].value !== firstObj.value ||
-              obj.techData[key].unit !== firstObj.unit ||
-              obj.techData[key].unit !== ''
-          ) === undefined
+        ? variants
+            .filter((variant) => key in variant.techData)
+            .find(
+              (obj) =>
+                obj.techData[key].value !== firstObj.value ||
+                obj.techData[key].unit !== firstObj.unit ||
+                obj.techData[key].unit !== ''
+            ) === undefined
         : true
 
     if (allTheSame) {


### PR DESCRIPTION
Sammenligneren funket ikke dersom man tilfeldigvis la til produkter som ikke hadde lik tech-data. Dvs at key ikke fantes i alle variantene. Da kræsjet alt. Fikser dette her ved å luke ut undefined, men vi bør kanskje vurdere å gjøre noe annet siden ikke alle varianter har lik tech data? 