### PR TITLE
Bug-fix: Måned er et tall fra 0-11, men legger på 1 så får vi 1-12

### DIFF
--- a/src/utils/string-util.ts
+++ b/src/utils/string-util.ts
@@ -29,7 +29,7 @@ export function findUniqueStringValues(arr: string[]): string {
 
 export const dateToString = (date: Date): string => {
   const day = date.getDate()
-  const month = date.getMonth()
+  const month = date.getMonth() + 1
   const year = date.getFullYear()
 
   return `${day}.${month}.${year}`


### PR DESCRIPTION
Fant ut at getMonth() returnerer et tall fra 0-11, så legger på 1 :) 

se: https://www.tutorialrepublic.com/faq/how-to-get-day-month-and-year-from-a-date-object-in-javascript.php