### PR TITLE
Fjerner antall bak filter labels

### DIFF
--- a/src/app/sok/sidebar/internals/CheckboxFilterInput.tsx
+++ b/src/app/sok/sidebar/internals/CheckboxFilterInput.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
-import { Button, Checkbox, CheckboxGroup, Detail } from '@navikt/ds-react'
+import { Button, Checkbox, CheckboxGroup } from '@navikt/ds-react'
 
 import { agreementKeyLabels } from '@/utils/agreement-util'
 import { Filter, SearchData } from '@/utils/api-util'
@@ -51,11 +51,7 @@ export const CheckboxFilterInput = ({ filter }: CheckboxFilterInputProps) => {
     return null
   }
 
-  const CheckboxLabel = ({ value, hitCount }: { value: string | number; hitCount: number }) => (
-    <>
-      {value} <Detail style={{ display: 'inline' }}>({hitCount})</Detail>
-    </>
-  )
+  const CheckboxLabel = ({ value }: { value: string | number }) => <>{value}</>
 
   return (
     <ShowMore
@@ -78,24 +74,24 @@ export const CheckboxFilterInput = ({ filter }: CheckboxFilterInputProps) => {
               {selectedUnavailableFilters?.map((f) => (
                 <Checkbox value={f} key={f}>
                   {/* Midlertidig mapping av agreement label frem frem til backend er riktig */}
-                  <CheckboxLabel value={f.includes('HMDB') ? agreementKeyLabels[f] : f} hitCount={0} />
+                  <CheckboxLabel value={f.includes('HMDB') ? agreementKeyLabels[f] : f} />
                 </Checkbox>
               ))}
               {filterData?.values.slice(0, 10).map((f) => (
                 <Checkbox value={f.key} key={f.key}>
-                  <CheckboxLabel value={f.label || f.key} hitCount={f.doc_count} />
+                  <CheckboxLabel value={f.label || f.key} />
                 </Checkbox>
               ))}
               {showAllValues &&
                 filterData?.values.slice(10).map((f) => (
                   <Checkbox value={f.key} key={f.key}>
-                    <CheckboxLabel value={f.label || f.key} hitCount={f.doc_count} />
+                    <CheckboxLabel value={f.label || f.key} />
                   </Checkbox>
                 ))}
               {!showAllValues &&
                 selectedInvisibleFilters?.map((f) => (
                   <Checkbox value={f.key} key={f.key}>
-                    <CheckboxLabel value={f.label || f.key} hitCount={f.doc_count} />
+                    <CheckboxLabel value={f.label || f.key} />
                   </Checkbox>
                 ))}
             </CheckboxGroup>


### PR DESCRIPTION
Trellokort: https://trello.com/c/pctfUJb2/134-fjerne-antallet-bak-filtrene-f%C3%B8r-ny-produktserie-indeksering-er-p%C3%A5-plass

Dette er en midlertidig fiks for å ikke forvirre bruker til vi får på plass riktig antall produkter basert på serier og ikke enkeltprodukter.

<img width="272" alt="image" src="https://github.com/navikt/hm-oversikt-frontend/assets/56063879/3143ef96-9300-4c12-8c37-df4caf6a738d">
