### PR TITLE
Combobox: Fjerner pilen når inputfeltet er tomt

### DIFF
--- a/src/app/sok/sidebar/internals/SearchCombobox.tsx
+++ b/src/app/sok/sidebar/internals/SearchCombobox.tsx
@@ -50,7 +50,7 @@ const SearchCombobox = ({ initialValue, onSearch }: Props) => {
       selectedOptions={selectedOption ? [selectedOption] : []}
       clearButton={true}
       allowNewValues={false}
-      toggleListButton={true}
+      toggleListButton={inputValue || selectedOption ? true : false}
       onKeyUpCapture={(event) => {
         if (event.key === 'Enter') {
           event.preventDefault()


### PR DESCRIPTION
Trellokort: https://trello.com/c/9GuuUa9R/203-rar-oppf%C3%B8rsel-p%C3%A5-comboboks-kontakte-aksel

Fjerner toggle når inputfeltet er tomt. Trengs ikke siden vi ikke har en default liste. 