### PR TITLE
Løse CORS-problemer

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,10 @@ const nextConfig = {
         source: '/products/_search:path*',
         destination: process.env.HM_SEARCH_URL + '/products/_search:path*',
       },
+      {
+        source: '/agreements/_search:path*',
+        destination: process.env.HM_SEARCH_URL + '/agreements/_search:path*',
+      },
     ]
   },
   images: {
@@ -27,9 +31,9 @@ const nextConfig = {
     ],
   },
   env: {
-    HM_SEARCH_URL: process.env.HM_SEARCH_URL,
+    //https://nextjs.org/docs/app/api-reference/next-config-js/env
+    //To add environment variables to the JavaScript bundle (client side) add the env config.
     IMAGE_PROXY_URL: process.env.IMAGE_PROXY_URL,
-    CDN_URL: process.env.CDN_URL,
   },
 }
 

--- a/src/app/produkt/[id]/page.tsx
+++ b/src/app/produkt/[id]/page.tsx
@@ -1,17 +1,12 @@
 import { mapAgreement } from '@/utils/agreement-util'
 import {
+  fetchProductsWithVariants,
   getAgreement,
   getProductWithVariants,
   getProductsInPost,
-  getProductsWithVariants,
   getSupplier,
 } from '@/utils/api-util'
-import {
-  Product,
-  mapProductFromSeriesId,
-  mapProductsFromAggregation,
-  mapProductsFromCollapse,
-} from '@/utils/product-util'
+import { Product, mapProductFromSeriesId, mapProductsFromCollapse } from '@/utils/product-util'
 import { mapSupplier } from '@/utils/supplier-util'
 
 import AccessoryOrSparePartPage from './AccessoryOrSparePartPage'
@@ -41,10 +36,7 @@ export default async function ProduktPage({ params: { id: seriesId } }: { params
   const isAccessoryOrSparePart = product.accessory || product.sparepart
   //TODO: Endre på product.attributes.matchingProducts når vi vet mer om hvordan vi skal knytte sammen product og tilbehør/reservedeler
   const matchingSeriesIds = product.attributes.matchingProducts?.length ? product.attributes.matchingProducts : null
-  const url = process.env.HM_SEARCH_URL + '/products/_search'
-  const matchingProducts = matchingSeriesIds
-    ? mapProductsFromAggregation(await getProductsWithVariants(matchingSeriesIds))
-    : null
+  const matchingProducts = matchingSeriesIds ? (await fetchProductsWithVariants(matchingSeriesIds)).products : null
 
   //TODO: Lage fetchmetode som henter alle produkter som er tilbehør og reservedel. Dermed må de matches på serieID.
   //Forløpig: Sender inn en tom liste som fører til ingen visning. Bruk mock for å teste lokalt:

--- a/src/utils/api-util.ts
+++ b/src/utils/api-util.ts
@@ -31,6 +31,9 @@ import { ProductDocResponse, SearchResponse, SeriesAggregationResponse } from '.
 
 export const PAGE_SIZE = 25
 
+//if HM_SEARCH_URL is undefined it means that we are on the client and we want to use relative url
+const HM_SEARCH_URL = process.env.HM_SEARCH_URL || ''
+
 export type SelectedFilters = Record<keyof typeof FilterCategories, Array<any>>
 export type Bucket = {
   key: number | string
@@ -238,7 +241,7 @@ export const fetchProducts = ({ from, to, searchData }: FetchProps): Promise<Fet
     },
   }
 
-  return fetch('/products/_search', {
+  return fetch(HM_SEARCH_URL + '/products/_search', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -745,7 +748,7 @@ const mapFilters = (data: any): FilterData => {
 }
 
 export async function getProduct(id: string): Promise<ProductDocResponse> {
-  const res = await fetch(process.env.HM_SEARCH_URL + `/products/_doc/${id}`, {
+  const res = await fetch(HM_SEARCH_URL + `/products/_doc/${id}`, {
     method: 'GET',
   })
 
@@ -753,7 +756,7 @@ export async function getProduct(id: string): Promise<ProductDocResponse> {
 }
 
 export async function getSupplier(id: string) {
-  const res = await fetch(process.env.HM_SEARCH_URL + `/suppliers/_doc/${id}`, {
+  const res = await fetch(HM_SEARCH_URL + `/suppliers/_doc/${id}`, {
     next: { revalidate: 900 },
     method: 'GET',
   })
@@ -762,7 +765,7 @@ export async function getSupplier(id: string) {
 }
 
 export async function getAgreement(id: string) {
-  const res = await fetch(process.env.HM_SEARCH_URL + `/agreements/_doc/${id}`, {
+  const res = await fetch(HM_SEARCH_URL + `/agreements/_doc/${id}`, {
     next: { revalidate: 900 },
     method: 'GET',
   })
@@ -772,7 +775,7 @@ export async function getAgreement(id: string) {
 
 //OBS Identifier skal utfases
 export async function getAgreementFromIdentifier(identifier: string): Promise<SearchResponse> {
-  const res = await fetch(process.env.HM_SEARCH_URL + `/agreements/_search`, {
+  const res = await fetch(HM_SEARCH_URL + `/agreements/_search`, {
     next: { revalidate: 900 },
     method: 'POST',
     headers: {
@@ -793,7 +796,7 @@ export async function getAgreementFromIdentifier(identifier: string): Promise<Se
 }
 
 export async function getProductWithVariants(seriesId: string): Promise<SearchResponse> {
-  const res = await fetch(process.env.HM_SEARCH_URL + '/products/_search', {
+  const res = await fetch(HM_SEARCH_URL + '/products/_search', {
     next: { revalidate: 900 },
     method: 'POST',
     headers: {
@@ -815,51 +818,8 @@ export type FetchSeriesResponse = {
   products: Product[]
 }
 
-export async function getProductsWithVariants(seriesIds: string[]): Promise<SeriesAggregationResponse> {
-  const res = await fetch(process.env.HM_SEARCH_URL + '/products/_search', {
-    next: { revalidate: 900 },
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      size: 0,
-      query: {
-        terms: {
-          seriesId: seriesIds,
-        },
-      },
-      sort: [{ _score: { order: 'desc' } }, { 'agreementInfo.postNr': 'asc' }, { 'agreementInfo.rank': 'asc' }],
-      aggregations: {
-        series_buckets: {
-          composite: {
-            sources: [
-              {
-                seriesId: {
-                  terms: {
-                    field: 'seriesId',
-                  },
-                },
-              },
-            ],
-          },
-          aggregations: {
-            products: {
-              top_hits: {
-                size: 150,
-              },
-            },
-          },
-        },
-      },
-    }),
-  })
-  return res.json()
-}
-
-//SWR fetcher
 export const fetchProductsWithVariants = (seriesIds: string[]): Promise<FetchSeriesResponse> => {
-  return fetch('/products/_search', {
+  return fetch(HM_SEARCH_URL + '/products/_search', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -911,7 +871,7 @@ export async function getProductsInPost(postIdentifier: string): Promise<SearchR
     },
   }
 
-  const res = await fetch(process.env.HM_SEARCH_URL + '/products/_search', {
+  const res = await fetch(HM_SEARCH_URL + '/products/_search', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -932,7 +892,7 @@ export type SuggestionsResponse = { suggestions: Suggestions }
 
 //TODO: Bør denne returnere Product? Vet ikke om vi trenger det
 export const fetchSuggestions = (term: string): Promise<SuggestionsResponse> => {
-  return fetch('/products/_search', {
+  return fetch(HM_SEARCH_URL + '/products/_search', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
Tidligere eksponerte vi variabelen HM_SEARCH_URL: process.env.HM_SEARCH_URL i next.confiig fila til klienten under env. Alt som ligger under env eksponeres til klient. Se: https://nextjs.org/docs/app/api-reference/next-config-js/env 

```
 env: {
    HM_SEARCH_URL: process.env.HM_SEARCH_URL,
    IMAGE_PROXY_URL: process.env.IMAGE_PROXY_URL,
    CDN_URL: process.env.CDN_URL,
  },
```

Dette førte til at localhost:8080 ble eksponert for klienten og da blir alle kall som hadde url process.env.HM_SEARCH_URL + "products_search" for eksempel sendt til til localhost:8080/products_search som da fører til CORS når det skjer fra localhost:3000. Vi løste dette tidligere ved å ikke legge på process.env.HM_SEARCH_URL foran relativ url når vi hentet data fra en klientkomponent men inkluderte process.env.HM_SEARCH_URL når vi hentet data fra serverkomponent. Men hvis en ressurs skal kunne brukes både fra klient og server så må HM_SEARCH_URL fjernes fra env i next config. Da settes process.env.HM_SEARCH_URL til localhost:8080 kun på serveside. Hvis man er på klient er den `undefined` og settes til en tom streng i api-fila. Dermed gjør rewrite sånn at man redirectes riktig på serveren og browseren forholder seg aldri til localhost:8080. Ved å fjerne denne så vet klienten kun om localhost:3000 og vi får ikke CORS-problemer. Vi kan nå alltid inkludere HM_SEARCH_URL når vi henter data slik at en metode både kan brukes på klient og server 😁

Dere kan se hvordan dette ser ut ved å: console.log(HM_SEARCH_URL). Refresh siden og se i console i browser og i terminalen. I terminalen på din maskin (på serveside) vil den være localhost:8080 og i nettleser vil den samtidig være en tom streng. 

Har pushet til Dev og der funker alt fint! Si ifra hvis det er dårlig forklart 😛