### PR TITLE
HOTFIX: Eksponer CDN_URL for klient

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,7 @@ const nextConfig = {
     //https://nextjs.org/docs/app/api-reference/next-config-js/env
     //To add environment variables to the JavaScript bundle (client side) add the env config.
     IMAGE_PROXY_URL: process.env.IMAGE_PROXY_URL,
+    CDN_URL: process.env.CDN_URL,
   },
 }
 


### PR DESCRIPTION
File-komponenten som bruker CDN-variabelen er egentlig en serverkomponent og derfor trenger egentlig ikke CDN-url å eksponeres for klienten siden det kun er der den brukes. Men når jeg testet å ta den tilbake så funket det og det gikk opp for meg at rammeavtalesiden og produktsiden ikke funker ikke uten javascript🤯🤯🤯. Det vil si at de ikke er serverkomponenter. Dette må graves i. Enn så lenge så tar jeg tilbake env-variabelen slik at det går an å laste ned filer i prod.  