### PR TITLE
Legger til assetprefix i auto deploy

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,1 @@
 HM_SEARCH_URL=http://hm-grunndata-search
-ASSET_PREFIX=https://cdn.nav.no/teamdigihot/hm-oversikt-frontend/prod

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -20,6 +20,7 @@ jobs:
       BUILD_ENV: prod
       IMAGE_PROXY_URL: https://finnhjelpemidler.nav.no/imageproxy
       CDN_URL: https://cdn.nav.no/teamdigihot/grunndata/media/v1/
+      ASSET_PREFIX: https://cdn.nav.no/teamdigihot/hm-oversikt-frontend/prod
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -50,6 +51,7 @@ jobs:
           build-args: |
             BUILD_ENV=${{ env.BUILD_ENV }}
             IMAGE_PROXY_URL=${{ env.IMAGE_PROXY_URL }}
+            ASSET_PREFIX=${{ env.ASSET_PREFIX }}
             CDN_URL=${{ env.CDN_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Å hente statiske filer fra CDN funket ikke slik jeg trodde fordi ASSETPREFIX-variabelen ikke var sendt med til dockerfila som ARG i auto-deploy scriptet. Jeg glemte det rett og slett 🙈 Unnskyld 😅

Her skriver Next om rekkefølgen til env variabler. Dersom den finnes i process.env så går ikke next videre å sjekker i env.production fila. Variabelen fantes i process.env fordi den er i Dockerfila men jeg hadde jo glemt å sende den inn dit som ARG så den var bare en tom streng😂 Og da gadd ikke Next å lete lenger siden en tom streng er noe. 
https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#environment-variable-load-order