### PR TITLE
Bugfix: Avoid scrolling when using router.push

### DIFF
--- a/src/app/sok/page.tsx
+++ b/src/app/sok/page.tsx
@@ -40,6 +40,7 @@ export default function Home() {
   const [copyPopupOpenState, setCopyPopupOpenState] = useState(false)
   const [mobileOverlayOpen, setMobileOverlayOpen] = useState(false)
   const [productSearchParams, setProductSearchParams] = useState<SearchParams>(mapProductSearchParams(searchParams))
+  const [searchQueryString, setSearQueryString] = useState('')
 
   const { searchData, setFilter, setSearchData } = useHydratedSearchStore()
 
@@ -85,16 +86,18 @@ export default function Home() {
 
   useEffect(() => {
     if (searchInitialized) {
-      router.push(
-        pathname +
-          toSearchQueryString({
-            ...searchData,
-            to: numberOfFetchedProducts,
-          }),
-        { scroll: false }
-      )
+      const newParamsString = toSearchQueryString({
+        ...searchData,
+        to: numberOfFetchedProducts,
+      })
+      setSearQueryString(newParamsString)
     }
-  }, [router, searchInitialized, searchData, numberOfFetchedProducts, pathname])
+  }, [router, searchParams, searchInitialized, searchData, numberOfFetchedProducts, pathname])
+
+  useEffect(() => {
+    console.log('CHANGED PARAMS', searchQueryString)
+    router.push(`${pathname}${searchQueryString}`, { scroll: false })
+  }, [router, pathname, searchQueryString])
 
   useEffect(() => {
     setShowSidebar(window.innerWidth >= 1100)


### PR DESCRIPTION
Trellokort: https://trello.com/c/xZnkttLQ/262-uke-42-bug-n%C3%A5r-man-utvider-s%C3%B8kelisten-blir-man-skrollet-til-toppen-scroll-position-beholdes-ikke

Tester her: https://finnhjelpemidler-alpha.intern.dev.nav.no/ 

Når man gjør en router.push i next så gjør man en full page load og man skroller til toppen av siden. Vi gjør dette når vi legger på search params i url. 👉 https://nextjs.org/docs/app/api-reference/functions/use-router#disabling-scroll-restoration. Ved å si `scroll: false `skroller man ikke til toppen av siden. I tillegg gjør vi kun router.push hvis searchparams endrer seg. Da unngå vi at siden blinker mange ganger fordi vi gjorde så mange router.push (veldig mange dependencies som endret seg i useEffecten)