### PR TITLE
Rette tilgjnegelighetsfeil ang. overskriftstruktur på et par nivå 2 sider

### DIFF
--- a/src/app/rammeavtale/AgreementList.tsx
+++ b/src/app/rammeavtale/AgreementList.tsx
@@ -31,7 +31,7 @@ const AgreementList = () => {
 
   return (
     <>
-      <Heading level="1" size="medium">
+      <Heading level="2" size="medium">
         Aktive avtaler
       </Heading>
       {/* TODO <Combobox></Combobox> */}

--- a/src/app/rammeavtale/page.tsx
+++ b/src/app/rammeavtale/page.tsx
@@ -10,84 +10,82 @@ import AgreementList from './AgreementList'
 
 export default async function AgreementsInfoPage() {
   return (
-    <>
-      <div className="agreement-page main">
-        <AnimateLayout>
-          <div className="agreement-page__content spacing-top--large spacing-bottom--xlarge">
-            <article>
-              <div className="flex flex--space-between">
-                <Heading level="1" size="large" className="spacing-bottom--small">
-                  Rammeavtaler på Hjelpemiddelområdet
-                </Heading>
-                <Image src="/nav-logo.svg" width="65" height="41" alt="" aria-hidden={true} />
-              </div>
-              <Heading level="2" size="small">
-                Om rammeavtaler med NAV
+    <div className="agreement-page main">
+      <AnimateLayout>
+        <div className="agreement-page__content spacing-top--large spacing-bottom--xlarge">
+          <article>
+            <div className="flex flex--space-between">
+              <Heading level="1" size="large" className="spacing-bottom--small">
+                Rammeavtaler på Hjelpemiddelområdet
               </Heading>
+              <Image src="/nav-logo.svg" width="65" height="41" alt="" aria-hidden={true} />
+            </div>
+            <Heading level="2" size="small">
+              Om rammeavtaler med NAV
+            </Heading>
 
-              <BodyLong>
-                NAV har avtale med flere leverandører for å kunne tilby et bredt utvalg av hjelpemidler innenfor noen
-                områder. Når et hjelpemiddel er på avtale med NAV så vil det være fremforhandlet en pris og blitt
-                gjennomført en kvalitetssikring av hjelpemiddelet.
-              </BodyLong>
-            </article>
-            <article>
-              <Heading level="1" size="medium">
-                Slik kan du se at et hjelpemiddel er på avtale med NAV
-              </Heading>
+            <BodyLong>
+              NAV har avtale med flere leverandører for å kunne tilby et bredt utvalg av hjelpemidler innenfor noen
+              områder. Når et hjelpemiddel er på avtale med NAV så vil det være fremforhandlet en pris og blitt
+              gjennomført en kvalitetssikring av hjelpemiddelet.
+            </BodyLong>
+          </article>
+          <article>
+            <Heading level="2" size="medium">
+              Slik kan du se at et hjelpemiddel er på avtale med NAV
+            </Heading>
 
-              <div className="agreement-page__icon-containers">
-                <div className="agreement-page__icon-container">
-                  <AgreementIcon rank={1} />
-                  <BodyLong>Er på avtale med NAV, og er rangert som nr 1 på sin delkontrakt.</BodyLong>
-                </div>
-                <div className="agreement-page__icon-container">
-                  <AgreementIcon rank={4} />
-                  <BodyLong>Er på avtale med NAV, og er rangert som nr 4 på sin delkontrakt.</BodyLong>
-                </div>
-                <div className="agreement-page__icon-container">
-                  <AgreementIcon rank={null} />
-                  <BodyLong>Er på avtale med NAV uten rangering.</BodyLong>
-                </div>
+            <div className="agreement-page__icon-containers">
+              <div className="agreement-page__icon-container">
+                <AgreementIcon rank={1} />
+                <BodyLong>Er på avtale med NAV, og er rangert som nr 1 på sin delkontrakt.</BodyLong>
               </div>
+              <div className="agreement-page__icon-container">
+                <AgreementIcon rank={4} />
+                <BodyLong>Er på avtale med NAV, og er rangert som nr 4 på sin delkontrakt.</BodyLong>
+              </div>
+              <div className="agreement-page__icon-container">
+                <AgreementIcon rank={null} />
+                <BodyLong>Er på avtale med NAV uten rangering.</BodyLong>
+              </div>
+            </div>
 
-              <ReadMore
-                content={
-                  <>
-                    <Heading level="2" size="small">
-                      Hva om hjelpemiddelet ikke har denne merkingen?
-                    </Heading>
-                    <BodyLong spacing>
-                      Det betyr at hjelpemiddelet ikke er på avtale med NAV. Dersom du vil søke om dette hjelpemiddelet,
-                      må behovet begrunnes godt. NAV Hjelpemiddelsentral vurderer om hjelpemiddelet kan innvilges eller
-                      ikke.
-                    </BodyLong>
-                    <Heading level="2" size="small">
-                      Hva om hjelpemiddelet er rangert som nummer 2,3 eller 4?
-                    </Heading>
-                    <BodyLong spacing>
-                      Det betyr at du kan søke om disse hjelpemidlene via NAV, men du må begrunne hvorfor rangeringen(e)
-                      foran ikke dekker behovet.
-                    </BodyLong>
-                    <Heading level="2" size="small">
-                      Hva vil det si at hjelpemiddelet ikke har rangering?
-                    </Heading>
-                    <BodyLong spacing>
-                      Det betyr at produktet er på avtale med NAV. Dette kan for eksempel være understell til en
-                      sittemodul, der samme understell passer til sittemoduler i flere rangeringer.
-                    </BodyLong>
-                  </>
-                }
-                buttonOpen={'Les mer'}
-                buttonClose={'Les mindre'}
-              />
-            </article>
-            <article>
-              <AgreementList />
-            </article>
-          </div>
-        </AnimateLayout>
-      </div>
-    </>
+            <ReadMore
+              content={
+                <>
+                  <Heading level="3" size="small">
+                    Hva om hjelpemiddelet ikke har denne merkingen?
+                  </Heading>
+                  <BodyLong spacing>
+                    Det betyr at hjelpemiddelet ikke er på avtale med NAV. Dersom du vil søke om dette hjelpemiddelet,
+                    må behovet begrunnes godt. NAV Hjelpemiddelsentral vurderer om hjelpemiddelet kan innvilges eller
+                    ikke.
+                  </BodyLong>
+                  <Heading level="3" size="small">
+                    Hva om hjelpemiddelet er rangert som nummer 2,3 eller 4?
+                  </Heading>
+                  <BodyLong spacing>
+                    Det betyr at du kan søke om disse hjelpemidlene via NAV, men du må begrunne hvorfor rangeringen(e)
+                    foran ikke dekker behovet.
+                  </BodyLong>
+                  <Heading level="3" size="small">
+                    Hva vil det si at hjelpemiddelet ikke har rangering?
+                  </Heading>
+                  <BodyLong spacing>
+                    Det betyr at produktet er på avtale med NAV. Dette kan for eksempel være understell til en
+                    sittemodul, der samme understell passer til sittemoduler i flere rangeringer.
+                  </BodyLong>
+                </>
+              }
+              buttonOpen={'Les mer'}
+              buttonClose={'Les mindre'}
+            />
+          </article>
+          <article>
+            <AgreementList />
+          </article>
+        </div>
+      </AnimateLayout>
+    </div>
   )
 }

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -66,7 +66,7 @@ const ProductCard = ({ product, removeProduct, showRank }: ProductCardProps) => 
           </div>
         </div>
         <div className="info">
-          <Heading size="xsmall" className="text-line-clamp">
+          <Heading level="3" size="xsmall" className="text-line-clamp">
             {product.title}
           </Heading>
         </div>


### PR DESCRIPTION
I møte i dag om tilgjengelighetserklæring i dag kom vi på at det det enkle oversriftstruktur feil på noen av sidene. Det er rammeavtale som ble nevnt. Jeg har rettet det samt kom jeg bort til en slik feil i sammligningsside som er rettet i denne PR.

![Screenshot 2023-11-28 at 11 14 17](https://github.com/navikt/hm-oversikt-frontend/assets/37771926/3e32084b-4f66-46db-b00e-b8e2c072ed40)
![Screenshot 2023-11-28 at 11 00 31](https://github.com/navikt/hm-oversikt-frontend/assets/37771926/1bb1e87a-19b5-486d-8b22-e0767e3e25c7)
