### PR TITLE
Fikser slik at kategorifilter på produktkort fungerer som filter

### DIFF
--- a/src/app/sok/SearchResults.tsx
+++ b/src/app/sok/SearchResults.tsx
@@ -22,11 +22,13 @@ const SearchResults = ({
   loadMore,
   isLoading,
   searchResultRef,
+  formRef,
 }: {
   loadMore?: () => void
   isLoading: boolean
   data?: Array<FetchResponse>
   searchResultRef: RefObject<HTMLHeadingElement>
+  formRef: RefObject<HTMLFormElement>
 }) => {
   const products = data?.map((d) => d.products).flat()
 
@@ -82,6 +84,7 @@ const SearchResults = ({
             product={product}
             firstChecked={firstChecked}
             setFirstChecked={setFirstChecked}
+            formRef={formRef}
           />
         ))}
       </ol>
@@ -98,10 +101,12 @@ const SearchResult = ({
   product,
   firstChecked,
   setFirstChecked,
+  formRef,
 }: {
   product: Product
   firstChecked: boolean
   setFirstChecked: (first: boolean) => void
+  formRef: RefObject<HTMLFormElement>
 }) => {
   const { setProductToCompare, removeProduct, productsToCompare, setCompareMenuState } = useHydratedCompareStore()
   const { setValue } = useFormContext<SearchData>()
@@ -173,7 +178,10 @@ const SearchResult = ({
                   className="search-result__product-category-button"
                   variant="tertiary"
                   size="small"
-                  onClick={() => setValue(`filters.produktkategori`, [product.isoCategoryTitle])}
+                  onClick={() => {
+                    setValue(`filters.produktkategori`, [product.isoCategoryTitle])
+                    formRef.current?.requestSubmit()
+                  }}
                 >
                   {product.isoCategoryTitle}
                 </Button>

--- a/src/app/sok/page.tsx
+++ b/src/app/sok/page.tsx
@@ -250,7 +250,13 @@ export default function Home() {
                   </Chips>
                 </>
               )}
-              <SearchResults data={data} loadMore={loadMore} isLoading={isLoading} searchResultRef={searchResultRef} />
+              <SearchResults
+                data={data}
+                loadMore={loadMore}
+                isLoading={isLoading}
+                searchResultRef={searchResultRef}
+                formRef={searchFormRef}
+              />
             </section>
           </div>
         </div>

--- a/src/app/sok/sidebar/internals/CheckboxFilterInput.tsx
+++ b/src/app/sok/sidebar/internals/CheckboxFilterInput.tsx
@@ -87,7 +87,6 @@ export const CheckboxFilterInput = ({ filter }: CheckboxFilterInputProps) => {
               ))}
               {filterData?.values.slice(0, 10).map((f) => (
                 <Checkbox value={f.key} key={f.key} onChange={onChange}>
-                  {/* NB! Fjerne bruk av label dersom vi ender opp med å ikke bruke det for rammeavtale?*/}
                   <CheckboxLabel value={f.label || f.key} />
                 </Checkbox>
               ))}


### PR DESCRIPTION
Kan testes i Dev

Trellokort: https://trello.com/c/tQT5QIFh/363-klikk-p%C3%A5-kategori-lenke-har-ingen-effekt

Ved fjerning av global state for en stund siden som tok vare på alle filtre og søkeord ble det glemt at det også finnes et filter på produktkortet. Nå er det fikset slik at dersom man klikker på produktkategori blir det et aktivt filter. 

