### PR TITLE
Remove extra text from series-description

### DIFF
--- a/src/app/produkt/[id]/InformationTabs.tsx
+++ b/src/app/produkt/[id]/InformationTabs.tsx
@@ -66,12 +66,8 @@ const SupplierInfo = ({ product, supplier }: { product: Product; supplier: Suppl
     <Heading level="2" size="xsmall">
       Produktbeskrivelse
     </Heading>
-    {product.attributes.shortdescription && <BodyLong spacing>{product.attributes.shortdescription}</BodyLong>}
     {product.attributes.text && <BodyLong>{product.attributes.text}</BodyLong>}
-
-    {!product.attributes.shortdescription &&
-      !product.attributes.text &&
-      'Ingen beskrivelse fra leverandør. Ta kontakt med leverandør for mer informasjon.'}
+    {!product.attributes.text && 'Ingen beskrivelse fra leverandør. Ta kontakt med leverandør for mer informasjon.'}
 
     <Heading level="2" size="xsmall" style={{ marginTop: '1.5rem' }}>
       Leverandør


### PR DESCRIPTION
https://nav-it.slack.com/archives/C0476GUUXD4/p1706012973889389

Produktbeskrivelse har tekst som er også hentet fra enkelte produkter og det blir feil. For eksempel for dette hvor det er krykker for høyre og venstre hånd, mens i beskrivelse det er hentet tekst fra et av to enkelte produktvarianter. 
https://finnhjelpemiddel.nav.no/produkt/HMDB-66429

Dette testes i dev.