### PR TITLE
forbedre kode og ta hensyn til  alle utgåtte datoer

### DIFF
--- a/src/app/produkt/[id]/ProductPageTopInfo.tsx
+++ b/src/app/produkt/[id]/ProductPageTopInfo.tsx
@@ -40,7 +40,6 @@ const ProductPageTopInfo = ({ product, supplier }: ProductPageTopInfoProps) => {
             <Heading level="1" size="large" spacing>
               {product.title}
             </Heading>
-            {/* TODO: check all expired dates */}
             {(allVariantsExpiredDates || allVariantsExpired) && (
               <div className="product-info__expired-propducts">
                 <Alert variant="warning">Dette produktet er utgått</Alert>


### PR DESCRIPTION
Dacapo Top viser alle utgåtte i prod selvom den har tre aktive varianter. Feilsøkingen viser at expired date kode i `ProductPageTopInfo.tsx` tar hensyn til expired dato for første produktvarianten og ikke alle. Dette er nå rettet i denne patch.

https://finnhjelpemiddel.nav.no/produkt/HMDB-38227 