### PR TITLE
Åpne spesifikk leverandør info når det eksisterer supplier id i URL

### DIFF
--- a/src/app/leverandorer/SupplierAccordion.tsx
+++ b/src/app/leverandorer/SupplierAccordion.tsx
@@ -10,8 +10,11 @@ interface Props {
 }
 
 export const SupplierAccordion = ({ supplier }: Props) => {
+  const location = window.location
+  const supplierId_url = location.hash.replace('#', '')
+
   return (
-    <Accordion.Item id={supplier.id}>
+    <Accordion.Item id={supplier.id} open={supplier.id === supplierId_url}>
       <Accordion.Header>
         <Heading level="2" size="small">
           {supplier.name}


### PR DESCRIPTION
Når man på produktsiden trykker på leverandørnavn kommer man til leverandørliste. Da bør den leverandørinfo være synlig/ åpen.

Dette kan testes i dev. 