### PR TITLE
Endre min/max filter til å håndtere enten eller situasjoner

### DIFF
--- a/src/utils/filter-util.ts
+++ b/src/utils/filter-util.ts
@@ -53,7 +53,6 @@ export const filterMinMax = (min: MinMaxFilter, max: MinMaxFilter, isHmsSuggesti
 
   if (!valueMin?.length && !valueMax?.length) return null
 
-  console.log({ keyMin }, { valueMin }, { keyMax }, { valueMax }, valueMax !== undefined)
   const mustClausesMin = []
   const mustClausesMax = []
   if (valueMin !== '') {
@@ -91,8 +90,6 @@ export const filterMinMax = (min: MinMaxFilter, max: MinMaxFilter, isHmsSuggesti
       },
     })
   }
-
-  console.log({ mustClausesMin }, { mustClausesMax })
 
   return {
     bool: {


### PR DESCRIPTION
Måtte endre på min/max filteret for å ta hensyn til at man kan enten treffe på min-tallet til produktet eller max-tallet, eller begge. Må testes godt i dev :)

Boolean uttrykk som brukes dersom. man har både min og max:

```
should_include = (product_min >= filter_min && product_min <= filter_max) || 
                 (product_max >= filter_min && product_max <= filter_max)
```
Skal i teorien funke sånn som tabellen viser her:

![image](https://github.com/navikt/hm-finnhjelpemiddel/assets/14221394/be2444e4-c6ce-416a-9286-c3a1a1c19fe1)

