### PR TITLE
Fjerne whitespaces fra søkeord

### DIFF
--- a/src/app/NavigationBar.tsx
+++ b/src/app/NavigationBar.tsx
@@ -28,8 +28,7 @@ const NavigationBar = () => {
     (searchTerm: string) => {
       setMenuOpen(false)
       const q = new URLSearchParams(window.location.search)
-      q.set('term', searchTerm)
-
+      q.set('term', searchTerm.trim())
       if (path.includes('sok')) {
         logNavigationEvent('søk', 'søk', 'Søk på søkesiden')
       } else if (path === '/') {


### PR DESCRIPTION
Trellokort - https://trello.com/c/MVfEu5yB

Merkelig nok denne lille endring med trim() ser ut å rette på bug nevnt av Håkon. Samtidig forstyrrer den ikke om det er flere ord i søkefeltet. 
Det må være mer vi trenger gjøre eller er det hele ?

Dette testes i dev.