### PR TITLE
Produkt properties/techdata table made complaint with wcag 2.5.3

### DIFF
--- a/src/app/produkt/[id]/ProductVariants.tsx
+++ b/src/app/produkt/[id]/ProductVariants.tsx
@@ -18,6 +18,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { FormProvider, useForm } from 'react-hook-form'
 import useSWR from 'swr'
 import { egenskaperText, hasDifferentValues, sortColumnsByRowKey } from './utils'
+import { defaultAriaLabel, getAriaLabel } from '@/utils/ariaLabel-util'
 
 export type SortColumns = {
   orderBy: string | null
@@ -204,16 +205,6 @@ const ProductVariants = ({ product }: { product: Product }) => {
     )
   }
 
-  const defaultAriaLabel: string = 'Trykk for å sortere stigende eller synkende'
-
-  const getAriaLabel = (ariaLabelKey: string) => {
-    return sortColumns.direction === 'ascending'
-      ? `${ariaLabelKey} sortert stigende, trykk for å endre`
-      : sortColumns.direction === 'descending'
-        ? `${ariaLabelKey} sortert synkende, trykk for å endre`
-        : defaultAriaLabel + ariaLabelKey
-  }
-
   type ExtendedFilterFormState = FilterFormState & {
     'HMS-nummer': unknown
     'Lev-artnr': unknown
@@ -308,7 +299,7 @@ const ProductVariants = ({ product }: { product: Product }) => {
           <Table zebraStripes>
             <Table.Header>
               <Table.Row className="variants-table__status-row">
-                {/*                <Table.HeaderCell></Table.HeaderCell>*/}
+                <Table.HeaderCell></Table.HeaderCell>
                 {productVariants.map((variant) => (
                   <Table.HeaderCell key={variant.id}>
                     {variant.hasAgreement ? (
@@ -343,7 +334,7 @@ const ProductVariants = ({ product }: { product: Product }) => {
                       className="sort-button"
                       aria-label={
                         sortColumns.orderBy === 'artName'
-                          ? getAriaLabel('Navn på variant ')
+                          ? getAriaLabel({ sortColumns: sortColumns, ariaLabelKey: 'Navn på variant ' })
                           : defaultAriaLabel + ' navn på variant'
                       }
                       aria-selected={sortColumns.orderBy === 'artName'}
@@ -379,7 +370,9 @@ const ProductVariants = ({ product }: { product: Product }) => {
                     <Button
                       className="sort-button"
                       aria-label={
-                        sortColumns.orderBy === 'HMS' ? getAriaLabel('HMS-nummer ') : defaultAriaLabel + ' HMS-nummer'
+                        sortColumns.orderBy === 'HMS'
+                          ? getAriaLabel({ sortColumns: sortColumns, ariaLabelKey: 'HMS-nummer ' })
+                          : defaultAriaLabel + ' HMS-nummer'
                       }
                       aria-selected={sortColumns.orderBy === 'HMS'}
                       size="xsmall"
@@ -427,7 +420,9 @@ const ProductVariants = ({ product }: { product: Product }) => {
                     <Button
                       className="sort-button"
                       aria-label={
-                        sortColumns.orderBy === 'levart' ? getAriaLabel('Lev-artnr ') : defaultAriaLabel + ' lev-artnr'
+                        sortColumns.orderBy === 'levart'
+                          ? getAriaLabel({ sortColumns: sortColumns, ariaLabelKey: 'Lev-artnr ' })
+                          : defaultAriaLabel + ' lev-artnr'
                       }
                       aria-selected={sortColumns.orderBy === 'levart'}
                       size="xsmall"
@@ -476,7 +471,9 @@ const ProductVariants = ({ product }: { product: Product }) => {
                       <Button
                         className="sort-button"
                         aria-label={
-                          sortColumns.orderBy === 'rank' ? getAriaLabel('Rangering ') : defaultAriaLabel + ' rangering'
+                          sortColumns.orderBy === 'rank'
+                            ? getAriaLabel({ sortColumns: sortColumns, ariaLabelKey: 'Rangering ' })
+                            : defaultAriaLabel + ' rangering'
                         }
                         aria-selected={sortColumns.orderBy === 'rank'}
                         size="xsmall"
@@ -529,7 +526,7 @@ const ProductVariants = ({ product }: { product: Product }) => {
                             className="sort-button"
                             aria-label={
                               sortColumns.orderBy === key
-                                ? getAriaLabel(key + ' ')
+                                ? getAriaLabel({ sortColumns: sortColumns, ariaLabelKey: key + ' ' })
                                 : defaultAriaLabel + ' ' + key.toLowerCase()
                             }
                             aria-selected={sortColumns.orderBy === key}

--- a/src/app/rammeavtale/AgreementList.tsx
+++ b/src/app/rammeavtale/AgreementList.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames'
 import NextLink from 'next/link'
 import { useMemo, useState } from 'react'
 import useSWR from 'swr'
+import { defaultAriaLabel, getAriaLabel } from '@/utils/ariaLabel-util'
 
 type SortColumns = {
   orderBy: string | null
@@ -71,16 +72,6 @@ const AgreementList = () => {
     )
   }
 
-  const defaultAriaLabel: string = 'Trykk for å sortere stigende eller synkende'
-
-  const getAriaLabel = (ariaLabelKey: string) => {
-    return sortColumn.direction === 'ascending'
-      ? `${ariaLabelKey} sortert stigende, trykk for å endre`
-      : sortColumn.direction === 'descending'
-        ? `${ariaLabelKey} sortert synkende, trykk for å endre`
-        : ariaLabelKey + defaultAriaLabel
-  }
-
   return (
     <>
       <HGrid columns={{ xs: '1fr 1fr 1fr', md: '4fr 1fr 1fr' }} align="center" className="agreement-page__list-header">
@@ -88,7 +79,14 @@ const AgreementList = () => {
           className={classNames('agreement-page__sort-button', {
             'agreement-page__sort-selected': sortColumn.orderBy === 'title',
           })}
-          aria-label={sortColumn.orderBy === 'title' ? getAriaLabel('Tittel ') : defaultAriaLabel + ' tittel'}
+          aria-label={
+            sortColumn.orderBy === 'title'
+              ? getAriaLabel({
+                  sortColumns: sortColumn,
+                  ariaLabelKey: 'Tittel ',
+                })
+              : defaultAriaLabel + ' tittel'
+          }
           aria-selected={sortColumn.orderBy === 'title'}
           size="xsmall"
           variant="tertiary"
@@ -103,7 +101,12 @@ const AgreementList = () => {
             'agreement-page__sort-selected': sortColumn.orderBy === 'published',
           })}
           aria-label={
-            sortColumn.orderBy === 'published' ? getAriaLabel('Aktiv fra dato ') : defaultAriaLabel + ' aktiv fra dato'
+            sortColumn.orderBy === 'published'
+              ? getAriaLabel({
+                  sortColumns: sortColumn,
+                  ariaLabelKey: 'Aktiv fra dato ',
+                })
+              : defaultAriaLabel + ' aktiv fra dato'
           }
           aria-selected={sortColumn.orderBy === 'published'}
           size="xsmall"
@@ -120,7 +123,12 @@ const AgreementList = () => {
             'agreement-page__sort-selected': sortColumn.orderBy === 'expires',
           })}
           aria-label={
-            sortColumn.orderBy === 'expires' ? getAriaLabel('Aktiv til dato ') : defaultAriaLabel + ' aktiv til dato'
+            sortColumn.orderBy === 'expires'
+              ? getAriaLabel({
+                  sortColumns: sortColumn,
+                  ariaLabelKey: 'Aktiv til dato ',
+                })
+              : defaultAriaLabel + ' aktiv til dato'
           }
           aria-selected={sortColumn.orderBy === 'expires'}
           size="xsmall"

--- a/src/utils/ariaLabel-util.ts
+++ b/src/utils/ariaLabel-util.ts
@@ -1,0 +1,9 @@
+export const defaultAriaLabel: string = 'Trykk for å sortere stigende eller synkende'
+
+export const getAriaLabel = ({ sortColumns, ariaLabelKey }: { sortColumns: any; ariaLabelKey: string }) => {
+  return sortColumns.direction === 'ascending'
+    ? `${ariaLabelKey} sortert stigende, trykk for å endre`
+    : sortColumns.direction === 'descending'
+      ? `${ariaLabelKey} sortert synkende, trykk for å endre`
+      : defaultAriaLabel + ariaLabelKey
+}


### PR DESCRIPTION
Trellokort - https://trello.com/c/lfXpY8cY

Da er `aria-label `og `aria-selected` implementert for egenskap og techdata tabell

Dette kan testes i dev.