### PR TITLE
Forbedre tastaturnavigering på produkt bilder pluss andre forbedringer

### DIFF
--- a/src/app/produkt/[id]/PhotoSlider.tsx
+++ b/src/app/produkt/[id]/PhotoSlider.tsx
@@ -133,7 +133,7 @@ const PhotoSlider = ({ photos }: ImageSliderProps) => {
                       100vw"
                 onClick={() => setModalIsOpen(true)}
                 tabIndex={0}
-                onKeyUpCapture={(event) => {
+                onKeyDown={(event) => {
                   if (event.key === 'Enter') {
                     event.preventDefault()
                     setModalIsOpen(true)
@@ -153,7 +153,7 @@ const PhotoSlider = ({ photos }: ImageSliderProps) => {
               animate="center"
               exit="exit"
               whileHover={{ scale: 1.1 }}
-              whileTap={{ scale: 0.9 }}
+              // whileTap={{ scale: 0.9 }}
               transition={{
                 x: { type: 'spring', stiffness: 300, damping: 30 },
                 opacity: { duration: 0.2 },
@@ -189,7 +189,7 @@ const PhotoSlider = ({ photos }: ImageSliderProps) => {
                       100vw"
                 onClick={() => setModalIsOpen(true)}
                 tabIndex={0}
-                onKeyUpCapture={(event) => {
+                onKeyDown={(event) => {
                   if (event.key === 'Enter') {
                     event.preventDefault()
                     setModalIsOpen(true)

--- a/src/app/produkt/[id]/PhotoSliderModal.tsx
+++ b/src/app/produkt/[id]/PhotoSliderModal.tsx
@@ -108,7 +108,7 @@ const PhotoSliderModal = ({
               }}
             >
               <Image
-                tabIndex={0}
+                tabIndex={-1}
                 draggable="false"
                 loader={largeImageLoader}
                 src={src}

--- a/src/app/rammeavtale/hjelpemidler/[agreementId]/AgreementPage.tsx
+++ b/src/app/rammeavtale/hjelpemidler/[agreementId]/AgreementPage.tsx
@@ -19,9 +19,9 @@ import {
   BodyLong,
   BodyShort,
   Button,
+  Heading,
   HGrid,
   HStack,
-  Heading,
   Link,
   Loader,
   Popover,
@@ -43,8 +43,7 @@ const AgreementPage = ({ agreement }: { agreement: Agreement }) => {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const showAccessoriesAndSparePartsList = useFlag("finnhjelpemiddel.vis-tilbehor-og-reservedel-lister")
-
+  const showAccessoriesAndSparePartsList = useFlag('finnhjelpemiddel.vis-tilbehor-og-reservedel-lister')
 
   const copyButtonMobileRef = useRef<HTMLButtonElement>(null)
   const copyButtonDesktopRef = useRef<HTMLButtonElement>(null)
@@ -159,14 +158,13 @@ const AgreementPage = ({ agreement }: { agreement: Agreement }) => {
           </div>
 
           <HGrid gap={{ xs: '3', md: '7' }} columns={{ xs: 1, sm: 3 }} className="spacing-top--small">
-
             <LinkPanelLocal
               href={
                 showAccessoriesAndSparePartsList.enabled
                   ? `/rammeavtale/${agreement.id}/tilbehor`
                   : `/rammeavtale/${agreement.id}#Tilbehor`
               }
-              icon={<PackageIcon color="#005b82" fontSize={'1.5rem'} />}
+              icon={<PackageIcon color="#005b82" fontSize={'1.5rem'} aria-hidden={true} />}
               title="Tilbehør"
               description="Gå til avtalens tilbehørslister i PDF-format"
             />
@@ -177,13 +175,13 @@ const AgreementPage = ({ agreement }: { agreement: Agreement }) => {
                   ? `/rammeavtale/${agreement.id}/reservedeler`
                   : `/rammeavtale/${agreement.id}#Reservedeler`
               }
-              icon={<WrenchIcon color="#005b82" fontSize={'1.5rem'} />}
+              icon={<WrenchIcon color="#005b82" fontSize={'1.5rem'} aria-hidden={true} />}
               title="Reservedeler"
               description="Gå til avtalens reservedellister i PDF-format"
             />
             <LinkPanelLocal
               href={`/rammeavtale/${agreement.id}`}
-              icon={<FilesIcon color="#005b82" fontSize={'1.5rem'} />}
+              icon={<FilesIcon color="#005b82" fontSize={'1.5rem'} aria-hidden={true} />}
               title="Om avtalen"
               description="Les om avtalen og se tilhørende dokumenter"
             />

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -10,9 +10,9 @@ import {
   Button,
   Checkbox,
   Detail,
+  Heading,
   HGrid,
   HStack,
-  Heading,
   Link,
   VStack,
 } from '@navikt/ds-react'
@@ -187,7 +187,7 @@ const ProductCard = ({
             <Button
               className="product-card__iso-button"
               variant="tertiary-neutral"
-              icon={<PackageIcon />}
+              icon={<PackageIcon aria-hidden />}
               onClick={() => handleIsoButton(product.isoCategoryTitle)}
             >
               {product.isoCategoryTitle}


### PR DESCRIPTION
Trellokort: https://trello.com/c/XLDd0Tjb

PR inneholder følgende forbedringer:
1. Skjule pynte-ikoner på product card og rammeavtale-sidene for skjermlesere
2. Unngå å ha fokus på et bilde når bildekarusellen er åpen
3. Bruke "Enter" tastaturmknappen for å åpne og lukke bildekarusellen / modalen


Dette testes i dev!