### PR TITLE
Picture size improve for android phone that still works for apple ones

### DIFF
--- a/src/app/produkt/[id]/product-page.scss
+++ b/src/app/produkt/[id]/product-page.scss
@@ -214,9 +214,24 @@
 
   .photo-container {
     /*    height: 390px;*/
-    min-height: 390px;
+    min-height: 200px;
     max-height: 480px;
+    width: 100%;
     height: auto;
+
+    @include mixins.for-size(phone-only) {
+      min-height: 200px;
+      max-height: 220px;
+      min-width: 200px;
+      max-width: 220px;
+    }
+
+    @include mixins.for-size(phone-up) {
+      min-height: 300px;
+      max-height: 350px;
+      min-width: 300px;
+      max-width: 350px;
+    }
 
     @include mixins.for-size(tablet-up) {
       min-height: 350px;
@@ -235,7 +250,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 100%;
     padding: $a-spacing-4 $a-spacing-2;
 
     @include mixins.for-size(tablet-up) {


### PR DESCRIPTION
Det med multidevice støtte er vanskelig, likevel vi må lære å forbedre dette overtid

Jeg har gjort små endringer og teste dette med følgende emulatorer for Android og Apple av type:
- Small Pixel API 35 5", Android 15 og Chrome
- Medium Pixel API 35 6,4",  Android 15 og Chrome
- iPhone SE 3rd Gen, IOS 18.1, Safari
- iPhone 16 Plus, IOS 18.1, Safari
- iPad Air 13" M2,  IOS 18.1, Safari

Dette kan også testes i dev