### PR TITLE
Deler siden - forbedringer i visning basert på forslag fra designeren

### DIFF
--- a/src/app/produkt/AccessoryOrSparePartPage.tsx
+++ b/src/app/produkt/AccessoryOrSparePartPage.tsx
@@ -19,11 +19,11 @@ const AccessoryOrSparePartPage = ({ product, matchingProducts }: Props) => {
       <ProductTop product={product} />
       <VStack>
         <Heading level="2" size="medium" spacing>
-          Produkter {product.accessory ? 'tilbehøret' : 'reservedelen'} passer til
+          Hjelpemidler {product.accessory ? 'tilbehøret' : 'reservedelen'} passer til
         </Heading>
         {matchingProducts && matchingProducts.length > 0 ? (
           <VStack gap={'4'}>
-            <HStack gap="1" justify="start">
+            <HStack gap="2" justify="start">
               {/*Her må det håndteres at et tilbehør kan ha flere avtaler*/}
               {matchingProducts.map((product, i) => (
                 /*<ProductCard product={product} key={`${i}-${product.id}`} type="plain" />*/

--- a/src/app/produkt/AccessoryOrSparePartPage.tsx
+++ b/src/app/produkt/AccessoryOrSparePartPage.tsx
@@ -1,12 +1,10 @@
 import { Product } from '@/utils/product-util'
 
 import { BodyLong, Heading } from '@/components/aksel-client'
-
-import ProductCard from '@/components/ProductCard'
 import { HStack, VStack } from '@navikt/ds-react'
 import ProductTop from '@/app/produkt/[id]/ProductTop'
 import { ProductPageLayout } from '@/app/produkt/ProductPageLayout'
-import { ProductCardAgreement } from '../rammeavtale/hjelpemidler/[agreementId]/ProductCardAgreement'
+import { ProductCardPart } from '@/app/produkt/ProductCardPart'
 
 type Props = {
   product: Product
@@ -27,7 +25,7 @@ const AccessoryOrSparePartPage = ({ product, matchingProducts }: Props) => {
               {/*Her må det håndteres at et tilbehør kan ha flere avtaler*/}
               {matchingProducts.map((product, i) => (
                 /*<ProductCard product={product} key={`${i}-${product.id}`} type="plain" />*/
-                <ProductCardAgreement
+                <ProductCardPart
                   product={product}
                   key={`${i}-${product.id}`}
                   variantCount={product.variantCount}

--- a/src/app/produkt/AccessoryOrSparePartPage.tsx
+++ b/src/app/produkt/AccessoryOrSparePartPage.tsx
@@ -3,9 +3,10 @@ import { Product } from '@/utils/product-util'
 import { BodyLong, Heading } from '@/components/aksel-client'
 
 import ProductCard from '@/components/ProductCard'
-import { VStack } from '@navikt/ds-react'
+import { HStack, VStack } from '@navikt/ds-react'
 import ProductTop from '@/app/produkt/[id]/ProductTop'
 import { ProductPageLayout } from '@/app/produkt/ProductPageLayout'
+import { ProductCardAgreement } from '../rammeavtale/hjelpemidler/[agreementId]/ProductCardAgreement'
 
 type Props = {
   product: Product
@@ -22,10 +23,18 @@ const AccessoryOrSparePartPage = ({ product, matchingProducts }: Props) => {
         </Heading>
         {matchingProducts && matchingProducts.length > 0 ? (
           <VStack gap={'4'}>
-            {/*Her må det håndteres at et tilbehør kan ha flere avtaler*/}
-            {matchingProducts.map((product, i) => (
-              <ProductCard product={product} key={`${i}-${product.id}`} type="plain" />
-            ))}
+            <HStack gap="1" justify="start">
+              {/*Her må det håndteres at et tilbehør kan ha flere avtaler*/}
+              {matchingProducts.map((product, i) => (
+                /*<ProductCard product={product} key={`${i}-${product.id}`} type="plain" />*/
+                <ProductCardAgreement
+                  product={product}
+                  key={`${i}-${product.id}`}
+                  variantCount={product.variantCount}
+                  rank={product.agreements?.[0]?.rank}
+                />
+              ))}
+            </HStack>
           </VStack>
         ) : (
           <BodyLong>

--- a/src/app/produkt/ProductCardPart.module.scss
+++ b/src/app/produkt/ProductCardPart.module.scss
@@ -35,7 +35,7 @@
 }
 
 .productSummary {
-  position: absolute;
+  padding: $a-spacing-8 0 0 0;
   top: 2.8rem;
 }
 

--- a/src/app/produkt/ProductCardPart.module.scss
+++ b/src/app/produkt/ProductCardPart.module.scss
@@ -1,0 +1,62 @@
+@use '@navikt/ds-tokens/dist/tokens' as *;
+
+.container {
+  position: relative;
+  border-radius: 0.5rem;
+  border: 1px solid $a-border-default;
+
+  &:hover {
+    outline: 1px solid $a-border-action;
+  }
+}
+
+.imageWrapper {
+  position: relative;
+  width: 96px;
+  height: 96px;
+}
+
+.agreementTag {
+  background-color: #ccf1d67a;
+  border-radius: 0.25rem;
+  border: 1px solid #99dead7a;
+  font-size: $a-font-size-medium;
+  padding: $a-spacing-1-alt $a-spacing-2;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 1;
+}
+
+.nonAgreementTag {
+  @extend .agreementTag;
+  background-color: #f0ecf4;
+  border: 1px solid #e0d8e9;
+}
+
+.productSummary {
+  position: absolute;
+  top: 2.8rem;
+}
+
+.link {
+  color: $a-text-default;
+  text-decoration: underline;
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+    color: $a-text-action;
+    background-color: white;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+  }
+}

--- a/src/app/produkt/ProductCardPart.tsx
+++ b/src/app/produkt/ProductCardPart.tsx
@@ -32,7 +32,6 @@ export const ProductCardPart = ({
           <ProductImage src={product.photos.at(0)?.uri} productTitle={product.title} />
         </Box>
         <VStack gap={{ xs: '1', md: '2' }}>
-          <HStack gap="2" align="center">
             {onAgreement ? (
               <Tag variant={'success-moderate'} className={styles.agreementTag}>
                 {currentRank === 99 ? 'På avtale' : `Rangering ${currentRank}`}
@@ -42,7 +41,6 @@ export const ProductCardPart = ({
                 Ikke på avtale
               </Tag>
             )}
-          </HStack>
           <Box className={styles.productSummary}>
             <Link
               className={styles.link}

--- a/src/app/produkt/ProductCardPart.tsx
+++ b/src/app/produkt/ProductCardPart.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { Product } from '@/utils/product-util'
+import { BodyShort, Box, HStack, Link, Tag, VStack } from '@navikt/ds-react'
+import NextLink from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import ProductImage from '@/components/ProductImage'
+import { logNavigationEvent } from '@/utils/amplitude'
+import styles from './ProductCardPart.module.scss'
+
+export const ProductCardPart = ({
+  product,
+  rank,
+  variantCount,
+}: {
+  product: Product
+  rank?: number
+  variantCount: number
+}) => {
+  const minRank = product.agreements && Math.min(...product.agreements.map((agreement) => agreement.rank))
+
+  const searchParams = useSearchParams()
+  const linkToProduct = `/produkt/${product.id}?${searchParams}`
+
+  const currentRank = rank ? rank : minRank
+  const onAgreement = currentRank !== Infinity
+
+  return (
+    <Box padding={{ xs: '2', md: '3' }} className={styles.container} width={{ xs: '100%', sm: '380px' }}>
+      <HStack gap="3" align="start" wrap={false}>
+        <Box className={styles.imageWrapper}>
+          <ProductImage src={product.photos.at(0)?.uri} productTitle={product.title} />
+        </Box>
+        <VStack gap={{ xs: '1', md: '2' }}>
+          <HStack gap="2" align="center">
+            {onAgreement ? (
+              <Tag variant={'success-moderate'} className={styles.agreementTag}>
+                {currentRank === 99 ? 'På avtale' : `Rangering ${currentRank}`}
+              </Tag>
+            ) : (
+              <Tag variant={'neutral-moderate'} className={styles.nonAgreementTag}>
+                Ikke på avtale
+              </Tag>
+            )}
+          </HStack>
+          <Box className={styles.productSummary}>
+            <Link
+              className={styles.link}
+              href={linkToProduct}
+              aria-label={`Gå til ${product.title}`}
+              as={NextLink}
+              onClick={() => logNavigationEvent('Produktkort_deler', 'produkt', product.title)}
+            >
+              <BodyShort weight="semibold">{product.title}</BodyShort>
+            </Link>
+            <BodyShort size="small">{`${variantCount} ${variantCount === 1 ? 'variant' : 'varianter'}`} </BodyShort>
+            <BodyShort size="small">{product.supplierName}</BodyShort>
+          </Box>
+        </VStack>
+      </HStack>
+    </Box>
+  )
+}

--- a/src/app/produkt/[id]/ProductTop.module.scss
+++ b/src/app/produkt/[id]/ProductTop.module.scss
@@ -23,6 +23,14 @@
   border: 1px solid #e0d8e9;
 }
 
+.partTag {
+  background-color: var(--a-surface-neutral-subtle);
+  border-radius: 0.25rem;
+  border: 1px solid #c6c2cc;
+  font-size: var(--a-font-size-medium);
+  padding: $a-spacing-1-alt $a-spacing-4;
+}
+
 .supplierLink {
   font-weight: $a-font-weight-bold;
 }

--- a/src/app/produkt/[id]/ProductTop.tsx
+++ b/src/app/produkt/[id]/ProductTop.tsx
@@ -25,6 +25,20 @@ const ProductSummary = ({ product, hmsartnr }: { product: Product; hmsartnr?: st
 
   return (
     <VStack gap={'8'}>
+      {product.accessory ? (
+        <HStack gap="3">
+          <Tag size={'small'} variant={'neutral-moderate'}>Tilbehør</Tag>
+        </HStack>
+      ): (
+        ''
+      )}
+      {product.sparePart ? (
+        <HStack gap="3">
+          <Tag size={'small'} variant={'neutral-moderate'}>Reservedel</Tag>
+        </HStack>
+      ): (
+        ''
+      )}
       <TagRow productAgreements={product.agreements} isExpired={isExpired} />
       <Link href={`/leverandorer#${product.supplierId}`} className={styles.supplierLink}>
         {product.supplierName}
@@ -67,7 +81,7 @@ const TagRow = ({
     productAgreements &&
     productAgreements?.length > 0 &&
     Math.min(...productAgreements.map((agreement) => agreement.rank))
-
+  const rankList = productAgreements?.map((agreement) => agreement.rank).sort((a, b) => a - b)
   return (
     <HStack justify={'start'} gap={'3'}>
       {topRank ? (
@@ -75,7 +89,12 @@ const TagRow = ({
           <Tag variant={'success-moderate'} className={styles.agreementTag}>
             {topRank === 99 ? 'På avtale' : `Rangering ${topRank}`}
           </Tag>
-          {productAgreements.length > 1 ? (
+          {productAgreements.length === 2 ? (
+            <Tag variant={'success-moderate'} className={styles.agreementTag}>
+              Rangering {rankList?.[1]}
+            </Tag>
+          ) : ''}
+          {productAgreements.length > 2 ? (
             <Tag variant={'success-moderate'} className={styles.agreementTag}>
               Flere delkontrakter
             </Tag>

--- a/src/app/produkt/[id]/ProductTop.tsx
+++ b/src/app/produkt/[id]/ProductTop.tsx
@@ -25,14 +25,7 @@ const ProductSummary = ({ product, hmsartnr }: { product: Product; hmsartnr?: st
 
   return (
     <VStack gap={'8'}>
-      {product.accessory || product.sparePart  ? (
-        <HStack gap="3">
-          <Tag size={'small'} variant={'neutral-moderate'}>{product.accessory ? 'Tilbehør' : 'Reservedel'}</Tag>
-        </HStack>
-      ): (
-        ''
-      )}
-      <TagRow productAgreements={product.agreements} isExpired={isExpired} />
+      <TagRow productAgreements={product.agreements} accessory={product.accessory} sparePart={product.sparePart} isExpired={isExpired} />
       <Link href={`/leverandorer#${product.supplierId}`} className={styles.supplierLink}>
         {product.supplierName}
       </Link>
@@ -65,9 +58,13 @@ const ProductSummary = ({ product, hmsartnr }: { product: Product; hmsartnr?: st
 
 const TagRow = ({
   productAgreements,
+  accessory,
+  sparePart,
   isExpired,
 }: {
   productAgreements: AgreementInfo[] | undefined
+  accessory: boolean | undefined
+  sparePart: boolean | undefined
   isExpired: boolean
 }) => {
   const topRank =
@@ -77,6 +74,14 @@ const TagRow = ({
   const rankList = productAgreements?.map((agreement) => agreement.rank).sort((a, b) => a - b)
   return (
     <HStack justify={'start'} gap={'3'}>
+      {accessory || sparePart  ? (
+        <HStack gap="3">
+          <Tag variant={'neutral-moderate'} className={styles.partTag}>
+            {accessory ? 'Tilbehør' : 'Reservedel'}</Tag>
+        </HStack>
+      ): (
+        ''
+      )}
       {topRank ? (
         <>
           <Tag variant={'success-moderate'} className={styles.agreementTag}>

--- a/src/app/produkt/[id]/ProductTop.tsx
+++ b/src/app/produkt/[id]/ProductTop.tsx
@@ -25,16 +25,9 @@ const ProductSummary = ({ product, hmsartnr }: { product: Product; hmsartnr?: st
 
   return (
     <VStack gap={'8'}>
-      {product.accessory ? (
+      {product.accessory || product.sparePart  ? (
         <HStack gap="3">
-          <Tag size={'small'} variant={'neutral-moderate'}>Tilbehør</Tag>
-        </HStack>
-      ): (
-        ''
-      )}
-      {product.sparePart ? (
-        <HStack gap="3">
-          <Tag size={'small'} variant={'neutral-moderate'}>Reservedel</Tag>
+          <Tag size={'small'} variant={'neutral-moderate'}>{product.accessory ? 'Tilbehør' : 'Reservedel'}</Tag>
         </HStack>
       ): (
         ''

--- a/src/app/rammeavtale/hjelpemidler/[agreementId]/ProductCardAgreement.tsx
+++ b/src/app/rammeavtale/hjelpemidler/[agreementId]/ProductCardAgreement.tsx
@@ -42,12 +42,8 @@ export const ProductCardAgreement = ({
                 Ikke på avtale
               </Tag>
             )}
-            { handleCompareClick ?
-              <CompareButton product={product} handleCompareClick={handleCompareClick} /> :
-              ''
-            }
 
-{/*            <CompareButton product={product} handleCompareClick={handleCompareClick} />*/}
+            <CompareButton product={product} handleCompareClick={handleCompareClick} />
           </HStack>
 
           <Box className={styles.imageWrapper}>

--- a/src/app/rammeavtale/hjelpemidler/[agreementId]/ProductCardAgreement.tsx
+++ b/src/app/rammeavtale/hjelpemidler/[agreementId]/ProductCardAgreement.tsx
@@ -42,8 +42,12 @@ export const ProductCardAgreement = ({
                 Ikke på avtale
               </Tag>
             )}
+            { handleCompareClick ?
+              <CompareButton product={product} handleCompareClick={handleCompareClick} /> :
+              ''
+            }
 
-            <CompareButton product={product} handleCompareClick={handleCompareClick} />
+{/*            <CompareButton product={product} handleCompareClick={handleCompareClick} />*/}
           </HStack>
 
           <Box className={styles.imageWrapper}>


### PR DESCRIPTION
Forbedre visning av tilbehør/ reservedel siden:
1. Tag på toppen som minner om dette er tilbehør eller reservedel
2. Tilknyttede hovedprodukter vises basert på eget produktkort og i en stabletliste.


Dette testes i dev.
f.eks. https://finnhjelpemiddel.intern.dev.nav.no/produkt/abcde27b-6f8e-4049-8786-9e9b80595b9e?sortering=Best_soketreff&term=158626&vis=Vis+reservedeler+og+tilbeh%C3%B8r&page=2